### PR TITLE
Make object and field API names case insensitive

### DIFF
--- a/force-app/main/default/lwc/lookup/lookup.html
+++ b/force-app/main/default/lwc/lookup/lookup.html
@@ -2,9 +2,14 @@
     <div class="slds-combobox_container">
         <div class={comboBoxClass} aria-expanded="false" aria-haspopup="listbox" role="combobox">
             <div class="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right" role="none">
-                <lightning-input type="search" onchange={handleKeyChange} onblur={handleBlur}
-                    label={searchLabel} class="searchInput"
-                    value={searchKey} placeholder={placeholderLabel}></lightning-input>
+                <lightning-input type="search"
+                    onchange={handleKeyChange}
+                    onblur={handleBlur}
+                    label={searchLabel}
+                    class="searchInput"
+                    value={searchKey}
+                    placeholder={placeholderLabel}
+                    disabled={disabledInput}></lightning-input>
             </div>
             <template if:true={contacts} >
                 <div id="listbox-id-1" class="slds-dropdown slds-dropdown_length-with-icon-7 slds-dropdown_fluid" role="listbox">

--- a/force-app/main/default/lwc/lookupContainer/lookupContainer.html
+++ b/force-app/main/default/lwc/lookupContainer/lookupContainer.html
@@ -3,8 +3,10 @@
         <p class="slds-p-horizontal_small">
             <c-lookup onselected={contactSelected}
                 objectname={objectname}
-                autoselectsinglematchingrecord="true"
-                keyfieldapiname={keyfieldapiname}></c-lookup>
+                keyfieldapiname={keyfieldapiname}
+                autoselectsinglematchingrecord={autoselectsinglematchingrecord}
+                lookup-label={lookupLabel}
+                invalid-option-chosen-message={invalidOptionChosenMessage}></c-lookup>
         </p>
         <template if:true={searchKey}>
             <div class="slds-p-horizontal_small slds-p-top_small">

--- a/force-app/main/default/lwc/lookupContainer/lookupContainer.js
+++ b/force-app/main/default/lwc/lookupContainer/lookupContainer.js
@@ -4,6 +4,9 @@ export default class LookupContainer extends LightningElement {
     @api cardTitle;
     @api objectname;
     @api keyfieldapiname;
+    @api autoselectsinglematchingrecord;
+    @api lookupLabel;
+    @api invalidOptionChosenMessage;
     @track contact;
     @track searchKey;
     contactSelected(event) {

--- a/force-app/main/default/lwc/lookupContainer/lookupContainer.js-meta.xml
+++ b/force-app/main/default/lwc/lookupContainer/lookupContainer.js-meta.xml
@@ -23,6 +23,14 @@
                 placeholder="Enter Field API name"
                 required="true"
                 default="Name"/>
+            <property name="autoselectsinglematchingrecord" type="Boolean" label="Auto select single matching record"
+                description="Auto select single matching record"/>
+            <property name="lookupLabel" type="String" label="Field Lookup label"
+                description="Field Lookup label"
+                placeholder="Field Lookup label"/>
+            <property name="invalidOptionChosenMessage" type="String" label="Invalid option chosen message"
+                description="Invalid option chosen message"
+                placeholder="Invalid option chosen message"/>
         </targetConfig>
     </targetConfigs>
 </LightningComponentBundle>


### PR DESCRIPTION
Field API name case insensitive, added validation for object and name, ability to override label, placeholder and invalid entry error message
For Issue #8 